### PR TITLE
[WIP] Change to relative paths

### DIFF
--- a/lib/orm/associations/association.js
+++ b/lib/orm/associations/association.js
@@ -1,4 +1,4 @@
-import { dasherize } from '@miragejs/server/lib/utils/inflector';
+import { dasherize } from '../../utils/inflector';
 
 /**
   @hide

--- a/lib/orm/associations/belongs-to.js
+++ b/lib/orm/associations/belongs-to.js
@@ -1,8 +1,8 @@
 import Association from './association';
 import _assign from 'lodash/assign';
-import { capitalize, camelize } from '@miragejs/server/lib/utils/inflector';
-import { toCollectionName } from '@miragejs/server/lib/utils/normalize-name';
-import assert from '@miragejs/server/lib/assert';
+import { capitalize, camelize } from '../../utils/inflector';
+import { toCollectionName } from '../../utils/normalize-name';
+import assert from '../../assert';
 
 /**
  * The belongsTo association adds a fk to the owner of the association

--- a/lib/orm/associations/has-many.js
+++ b/lib/orm/associations/has-many.js
@@ -3,9 +3,9 @@ import Collection from '../collection';
 import PolymorphicCollection from '../polymorphic-collection';
 import _assign from 'lodash/assign';
 import _compact from 'lodash/compact';
-import { capitalize, camelize, singularize } from '@miragejs/server/lib/utils/inflector';
-import { toCollectionName } from '@miragejs/server/lib/utils/normalize-name';
-import assert from '@miragejs/server/lib/assert';
+import { capitalize, camelize, singularize } from '../../utils/inflector';
+import { toCollectionName } from '../../utils/normalize-name';
+import assert from '../../assert';
 
 /**
  * @class HasMany

--- a/lib/orm/model.js
+++ b/lib/orm/model.js
@@ -1,6 +1,6 @@
 import BelongsTo from './associations/belongs-to';
 import HasMany from './associations/has-many';
-import { toCollectionName, toInternalCollectionName } from '@miragejs/server/lib/utils/normalize-name';
+import { toCollectionName, toInternalCollectionName } from '../utils/normalize-name';
 import extend from '../utils/extend';
 import assert from '../assert';
 import Collection from './collection';

--- a/lib/orm/schema.js
+++ b/lib/orm/schema.js
@@ -1,5 +1,5 @@
 import { pluralize, camelize, dasherize } from '../utils/inflector';
-import { toCollectionName, toModelName } from '@miragejs/server/lib/utils/normalize-name';
+import { toCollectionName, toModelName } from '../utils/normalize-name';
 import Association from './associations/association';
 import Collection from './collection';
 import _assign from 'lodash/assign';

--- a/lib/route-handler.js
+++ b/lib/route-handler.js
@@ -1,6 +1,6 @@
 import { Promise } from 'rsvp';
 
-import { MirageError } from '@miragejs/server/lib/assert';
+import { MirageError } from './assert';
 import Response from './response';
 import FunctionHandler from './route-handlers/function';
 import ObjectHandler from './route-handlers/object';

--- a/lib/route-handlers/base.js
+++ b/lib/route-handlers/base.js
@@ -1,5 +1,5 @@
-import assert from '@miragejs/server/lib/assert';
-import { camelize, singularize, dasherize } from '@miragejs/server/lib/utils/inflector';
+import assert from '../assert';
+import { camelize, singularize, dasherize } from '../utils/inflector';
 import HasMany from '../orm/associations/has-many';
 
 const PATH_VAR_REGEXP = /^:/;

--- a/lib/route-handlers/function.js
+++ b/lib/route-handlers/function.js
@@ -1,6 +1,6 @@
 import BaseRouteHandler from './base';
-import assert from '@miragejs/server/lib/assert';
-import { dasherize } from '@miragejs/server/lib/utils/inflector';
+import assert from '../assert';
+import { dasherize } from '../utils/inflector';
 
 /**
  * @hide

--- a/lib/route-handlers/shorthands/base.js
+++ b/lib/route-handlers/shorthands/base.js
@@ -1,4 +1,4 @@
-import { toCollectionName } from '@miragejs/server/lib/utils/normalize-name';
+import { toCollectionName } from '../../utils/normalize-name';
 import BaseRouteHandler from '../base';
 
 /**

--- a/lib/route-handlers/shorthands/delete.js
+++ b/lib/route-handlers/shorthands/delete.js
@@ -1,6 +1,6 @@
-import assert from '@miragejs/server/lib/assert';
+import assert from '../../assert';
 import BaseShorthandRouteHandler from './base';
-import { pluralize, camelize } from '@miragejs/server/lib/utils/inflector';
+import { pluralize, camelize } from '../../utils/inflector';
 
 /**
  * @hide

--- a/lib/route-handlers/shorthands/get.js
+++ b/lib/route-handlers/shorthands/get.js
@@ -1,7 +1,7 @@
-import assert from '@miragejs/server/lib/assert';
+import assert from '../../assert';
 import BaseShorthandRouteHandler from './base';
-import { Response } from '@miragejs/server/lib/index';
-import { singularize, camelize } from '@miragejs/server/lib/utils/inflector';
+import { Response } from '../../index';
+import { singularize, camelize } from '../../utils/inflector';
 
 /**
  * @hide

--- a/lib/route-handlers/shorthands/head.js
+++ b/lib/route-handlers/shorthands/head.js
@@ -1,7 +1,7 @@
-import assert from '@miragejs/server/lib/assert';
+import assert from '../../assert';
 import BaseShorthandRouteHandler from './base';
-import { Response } from '@miragejs/server/lib/index';
-import { camelize } from '@miragejs/server/lib/utils/inflector';
+import { Response } from '../../index';
+import { camelize } from '../../utils/inflector';
 
 /**
  * @hide

--- a/lib/route-handlers/shorthands/post.js
+++ b/lib/route-handlers/shorthands/post.js
@@ -1,6 +1,6 @@
-import assert from '@miragejs/server/lib/assert';
+import assert from '../../assert';
 import BaseShorthandRouteHandler from './base';
-import { camelize } from '@miragejs/server/lib/utils/inflector';
+import { camelize } from '../../utils/inflector';
 
 /**
  * @hide

--- a/lib/route-handlers/shorthands/put.js
+++ b/lib/route-handlers/shorthands/put.js
@@ -1,6 +1,6 @@
-import assert from '@miragejs/server/lib/assert';
+import assert from '../../assert';
 import BaseShorthandRouteHandler from './base';
-import { camelize } from '@miragejs/server/lib/utils/inflector';
+import { camelize } from '../../utils/inflector';
 
 /**
  * @hide

--- a/lib/serializer-registry.js
+++ b/lib/serializer-registry.js
@@ -1,8 +1,8 @@
-import Model from '@miragejs/server/lib/orm/model';
-import Collection from '@miragejs/server/lib/orm/collection';
-import PolymorphicCollection from '@miragejs/server/lib/orm/polymorphic-collection';
-import Serializer from '@miragejs/server/lib/serializer';
-import JsonApiSerializer from '@miragejs/server/lib/serializers/json-api-serializer';
+import Model from './orm/model';
+import Collection from './orm/collection';
+import PolymorphicCollection from './orm/polymorphic-collection';
+import Serializer from './serializer';
+import JsonApiSerializer from './serializers/json-api-serializer';
 import { pluralize, camelize } from './utils/inflector';
 import assert from './assert';
 

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -25,7 +25,7 @@ import _ from 'lodash';
 
     ```js
     // mirage/serializers/application.js
-    import { JSONAPISerializer } from '@miragejs/server/lib/index';
+    import { JSONAPISerializer } from './index';
 
     export default JSONAPISerializer;
     ```
@@ -34,7 +34,7 @@ import _ from 'lodash';
 
     ```js
     // mirage/serializers/application.js
-    import { ActiveModelSerializer } from '@miragejs/server/lib/index';
+    import { ActiveModelSerializer } from './index';
 
     export default ActiveModelSerializer;
     ```
@@ -43,7 +43,7 @@ import _ from 'lodash';
 
     ```js
     // mirage/serializers/application.js
-    import { RestSerializer } from '@miragejs/server/lib/index';
+    import { RestSerializer } from './index';
 
     export default RestSerializer;
     ```
@@ -52,7 +52,7 @@ import _ from 'lodash';
 
   ```js
   // mirage/serializers/application.js
-  import { Serializer } from '@miragejs/server/lib/index';
+  import { Serializer } from './index';
 
   export default Serializer;
   ```
@@ -939,7 +939,7 @@ class Serializer {
 
     ```js
     // serializers/author.js
-    import { JSONAPISerializer } from '@miragejs/server/lib/index';
+    import { JSONAPISerializer } from './index';
 
     export default JSONAPISerializer.extend({
 

--- a/lib/serializers/json-api-serializer.js
+++ b/lib/serializers/json-api-serializer.js
@@ -2,7 +2,7 @@ import Serializer from '../serializer';
 import { dasherize, pluralize, camelize } from '../utils/inflector';
 import _get from 'lodash/get';
 import _ from 'lodash';
-import assert from '@miragejs/server/lib/assert';
+import assert from '../assert';
 
 /**
   The JSONAPISerializer.

--- a/lib/server.js
+++ b/lib/server.js
@@ -2,10 +2,10 @@
 
 import { Promise } from 'rsvp';
 import { singularize, pluralize, camelize } from './utils/inflector';
-import { toCollectionName, toInternalCollectionName } from '@miragejs/server/lib/utils/normalize-name';
+import { toCollectionName, toInternalCollectionName } from './utils/normalize-name';
 // import { getModels } from './ember-data';
 // import { hasEmberData } from './utils/ember-data';
-import isAssociation from '@miragejs/server/lib/utils/is-association';
+import isAssociation from './utils/is-association';
 import Pretender from 'pretender';
 import Db from './db';
 import Schema from './orm/schema';

--- a/lib/start-mirage.js
+++ b/lib/start-mirage.js
@@ -1,7 +1,10 @@
-import { getWithDefault } from '@ember/object';
-import readModules from '@miragejs/server/lib/utils/read-modules';
-import Server from '@miragejs/server/lib/server';
+import readModules from './utils/read-modules';
+import Server from './server';
 import _assign from 'lodash/assign';
+
+const getWithDefault = (obj, key, def) => {
+  return obj[key] || def;
+};
 
 /**
   Helper to start mirage. This should not be called directly. In rfc232/rfc268

--- a/lib/utils/normalize-name.js
+++ b/lib/utils/normalize-name.js
@@ -3,7 +3,7 @@ import {
   pluralize,
   singularize,
   dasherize
-} from '@miragejs/server/lib/utils/inflector';
+} from './inflector';
 
 /**
   @hide

--- a/lib/utils/read-modules.js
+++ b/lib/utils/read-modules.js
@@ -2,10 +2,11 @@
 /* eslint-env node */
 'use strict';
 
-import { assert } from '@ember/debug';
 import _camelCase from 'lodash/camelCase';
-import { pluralize } from '@miragejs/server/lib/utils/inflector';
-import require from 'require';
+import { pluralize } from '../utils/inflector';
+
+const require = (moduleName) => false;
+const assert = (message, condition) => !condition ? console.warn(message) : null;
 
 /**
   This function looks through all files that have been loaded by Ember CLI and


### PR DESCRIPTION
I had a few problems while working at https://github.com/samselikoff/ember-cli-mirage/pull/1633.

This fixes *some of them*, fixes are not finished (some of them are temporary just to see if I could get it working)

To note:
- We don't have global `require` anymore (at least not now, we have to figure out a way)
- As the files are imported by path on `ember-cli-mirage`, our rollup alias that does the mapping from `@miragejs/server` to the project root does not work (haven't found a solution too)
- `assert` and `require` are *mocked* just so this errors get out of the way when trying to get `ember-cli-mirage` to pass the tests
