### PR TITLE
Use assign method from lodash to make IE work again

### DIFF
--- a/lib/db-collection.js
+++ b/lib/db-collection.js
@@ -1,10 +1,10 @@
-import { map, isEqual } from "lodash-es";
+import { map, isEqual, assign } from "lodash-es";
 
 function duplicate(data) {
   if (Array.isArray(data)) {
     return data.map(duplicate);
   } else {
-    return Object.assign({}, data);
+    return assign({}, data);
   }
 }
 
@@ -206,7 +206,7 @@ class DbCollection {
     if (record) {
       return record;
     } else {
-      let mergedAttributes = Object.assign(attributesForCreate, query);
+      let mergedAttributes = assign(attributesForCreate, query);
       let createdRecord = this.insert(mergedAttributes);
 
       return createdRecord;
@@ -246,7 +246,7 @@ class DbCollection {
       let changedRecords = [];
 
       this._records.forEach(record => {
-        let oldRecord = Object.assign({}, record);
+        let oldRecord = assign({}, record);
 
         this._updateRecord(record, attrs);
 

--- a/lib/factory.js
+++ b/lib/factory.js
@@ -1,10 +1,10 @@
-import { isFunction, mapValues, isPlainObject } from "lodash-es";
+import { assign, isFunction, mapValues, isPlainObject } from "lodash-es";
 import referenceSort from "./utils/reference-sort";
 
 let Factory = function() {
   this.build = function(sequence) {
     let object = {};
-    let topLevelAttrs = Object.assign({}, this.attrs);
+    let topLevelAttrs = assign({}, this.attrs);
     delete topLevelAttrs.afterCreate;
     Object.keys(topLevelAttrs).forEach(attr => {
       if (Factory.isTrait.call(this, attr)) {
@@ -46,7 +46,7 @@ let Factory = function() {
 
 Factory.extend = function(attrs) {
   // Merge the new attributes with existing ones. If conflict, new ones win.
-  let newAttrs = Object.assign({}, this.attrs, attrs);
+  let newAttrs = assign({}, this.attrs, attrs);
 
   let Subclass = function() {
     this.attrs = newAttrs;

--- a/lib/orm/associations/belongs-to.js
+++ b/lib/orm/associations/belongs-to.js
@@ -1,3 +1,4 @@
+import { assign } from "lodash-es";
 import Association from "./association";
 import { capitalize, camelize } from "../../utils/inflector";
 import assert from "../../assert";
@@ -51,7 +52,7 @@ export default class BelongsTo extends Association {
     let foreignKey = this.getForeignKey();
     let associationHash = { [key]: this };
 
-    modelPrototype.belongsToAssociations = Object.assign(
+    modelPrototype.belongsToAssociations = assign(
       modelPrototype.belongsToAssociations,
       associationHash
     );

--- a/lib/orm/associations/has-many.js
+++ b/lib/orm/associations/has-many.js
@@ -1,7 +1,7 @@
 import Association from "./association";
 import Collection from "../collection";
 import PolymorphicCollection from "../polymorphic-collection";
-import { compact } from "lodash-es";
+import { assign, compact } from "lodash-es";
 import { capitalize, camelize } from "../../utils/inflector";
 import assert from "../../assert";
 
@@ -52,7 +52,7 @@ export default class HasMany extends Association {
     let foreignKey = this.getForeignKey();
     let associationHash = { [key]: this };
 
-    modelPrototype.hasManyAssociations = Object.assign(
+    modelPrototype.hasManyAssociations = assign(
       modelPrototype.hasManyAssociations,
       associationHash
     );

--- a/lib/orm/model.js
+++ b/lib/orm/model.js
@@ -4,7 +4,7 @@ import extend from "../utils/extend";
 import assert from "../assert";
 import Collection from "./collection";
 import PolymorphicCollection from "./polymorphic-collection";
-import { values, compact } from "lodash-es";
+import { assign, values, compact } from "lodash-es";
 
 /**
   Models wrap your database, and allow you to define relationships.
@@ -1004,7 +1004,7 @@ class Model {
         ];
         let currentIdsForInverse =
           inverseCollection.find(model.id)[inverse.getForeignKey()] || [];
-        let newIdsForInverse = Object.assign([], currentIdsForInverse);
+        let newIdsForInverse = assign([], currentIdsForInverse);
         let newId, alreadyAssociatedWith;
 
         if (inverse.isPolymorphic) {

--- a/lib/orm/schema.js
+++ b/lib/orm/schema.js
@@ -2,7 +2,7 @@ import { camelize, dasherize } from "../utils/inflector";
 import Association from "./associations/association";
 import Collection from "./collection";
 import assert from "../assert";
-import { forIn } from "lodash-es";
+import { forIn, assign } from "lodash-es";
 
 /**
   The primary use of the `Schema` class is to use it to find Models and Collections via the `Model` class methods.
@@ -400,7 +400,7 @@ export default class Schema {
   associationsFor(modelName) {
     let modelClass = this.modelClassFor(modelName);
 
-    return Object.assign(
+    return assign(
       {},
       modelClass.belongsToAssociations,
       modelClass.hasManyAssociations

--- a/lib/serializer-registry.js
+++ b/lib/serializer-registry.js
@@ -1,3 +1,4 @@
+import { assign } from "lodash-es";
 import Model from "./orm/model";
 import Collection from "./orm/collection";
 import PolymorphicCollection from "./orm/polymorphic-collection";
@@ -38,7 +39,7 @@ export default class SerializerRegistry {
             this._container.inflector.pluralize(collection.modelName)
           ] = serializer.serialize(collection, request);
         } else {
-          json = Object.assign(json, serializer.serialize(collection, request));
+          json = assign(json, serializer.serialize(collection, request));
         }
 
         return json;
@@ -89,7 +90,7 @@ export default class SerializerRegistry {
 
   registerSerializers(newSerializerMaps) {
     let currentSerializerMap = this._serializerMap || {};
-    this._serializerMap = Object.assign(
+    this._serializerMap = assign(
       currentSerializerMap,
       newSerializerMaps
     );

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -11,7 +11,8 @@ import {
   get,
   flatten,
   compact,
-  uniqBy
+  uniqBy,
+  assign
 } from "lodash-es";
 
 /**
@@ -562,7 +563,7 @@ class Serializer {
         resourceHash[resourceHashKey]
       );
     } else {
-      newJson = Object.assign(json, resourceHash);
+      newJson = assign(json, resourceHash);
     }
 
     return newJson;
@@ -683,7 +684,7 @@ class Serializer {
     }
 
     if (this.embed) {
-      let newDidSerialize = Object.assign({}, didSerialize);
+      let newDidSerialize = assign({}, didSerialize);
       newDidSerialize[model.modelName] = newDidSerialize[model.modelName] || {};
       newDidSerialize[model.modelName][model.id] = true;
 
@@ -733,7 +734,7 @@ class Serializer {
         return memo;
       }, {});
     } else {
-      attrs = Object.assign(attrs, model.attrs);
+      attrs = assign(attrs, model.attrs);
     }
 
     // Remove fks
@@ -750,7 +751,7 @@ class Serializer {
     @hide
    */
   _maybeAddAssociationIds(model, attrs) {
-    let newHash = Object.assign({}, attrs);
+    let newHash = assign({}, attrs);
 
     if (this.serializeIds === "always") {
       model.associationKeys.forEach(key => {

--- a/lib/utils/extend.js
+++ b/lib/utils/extend.js
@@ -1,4 +1,4 @@
-import { has } from "lodash-es";
+import { assign, has } from "lodash-es";
 
 /**
   @hide
@@ -19,12 +19,12 @@ export default function extend(protoProps, staticProps) {
 
   // Add static properties to the constructor function, if supplied.
 
-  Object.assign(Child, Parent, staticProps);
+  assign(Child, Parent, staticProps);
 
   // Add prototype properties (instance properties) to the subclass,
   // if supplied.
   if (protoProps) {
-    Object.assign(Child.prototype, protoProps);
+    assign(Child.prototype, protoProps);
   }
 
   return Child;


### PR DESCRIPTION
The latest ember-cli-mirage stopped working on IE11. After some research I found out that this happens most likely because of the `Object.assign` method (hopefully this is the only reason). Anyways I suggest reverting the changes from the commit 3867bcdb and use the assign method from lodash.