### PR TITLE
[WIP] Rollup config, and jest integration tests against builds

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,8 @@ module.exports = {
   ],
   env: {
     "jest/globals": true,
-    es6: true
+    es6: true,
+    node: true
   },
   rules: {
     camelcase: 0,

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = require("./dist/mirage-cjs.js");

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,38 @@ let browser = {
   }
 };
 
+let esmBundle = {
+  displayName: "esm bundle",
+  transformIgnorePatterns: ["<rootDir>/node_modules/(?!lodash-es)"],
+  setupFilesAfterEnv: ["jest-extended"],
+  testMatch: ["**/__tests__/integration/**/*-test.[jt]s?(x)"],
+  moduleNameMapper: {
+    "@lib(.*)": "<rootDir>/dist/mirage-ems",
+    "@miragejs/server": "<rootDir>/dist/mirage-ems"
+  }
+};
+
+let umdBundle = {
+  displayName: "umd bundle",
+  setupFilesAfterEnv: ["jest-extended"],
+  testMatch: ["**/__tests__/integration/**/*-test.[jt]s?(x)"],
+  moduleNameMapper: {
+    "@lib(.*)": "<rootDir>/dist/mirage-umd",
+    "@miragejs/server": "<rootDir>/dist/mirage-umd"
+  }
+};
+
+let cjsBundle = {
+  displayName: "cjs bundle",
+  transformIgnorePatterns: ["<rootDir>/node_modules/(?!lodash-es)"],
+  setupFilesAfterEnv: ["jest-extended"],
+  testMatch: ["**/__tests__/integration/**/*-test.[jt]s?(x)"],
+  moduleNameMapper: {
+    "@lib(.*)": "<rootDir>/dist/mirage-cjs",
+    "@miragejs/server": "<rootDir>/dist/mirage-cjs"
+  }
+};
+
 // let eslint = {
 //   displayName: "lint",
 //   runner: "jest-runner-eslint",
@@ -20,5 +52,5 @@ let browser = {
 // };
 
 module.exports = {
-  projects: [browser]
+  projects: [browser, esmBundle, cjsBundle, umdBundle]
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,37 +9,37 @@ let browser = {
   }
 };
 
-let esmBundle = {
-  displayName: "esm bundle",
-  transformIgnorePatterns: ["<rootDir>/node_modules/(?!lodash-es)"],
-  setupFilesAfterEnv: ["jest-extended"],
-  testMatch: ["**/__tests__/integration/**/*-test.[jt]s?(x)"],
-  moduleNameMapper: {
-    "@lib(.*)": "<rootDir>/dist/mirage-ems",
-    "@miragejs/server": "<rootDir>/dist/mirage-ems"
-  }
-};
-
-let umdBundle = {
-  displayName: "umd bundle",
-  setupFilesAfterEnv: ["jest-extended"],
-  testMatch: ["**/__tests__/integration/**/*-test.[jt]s?(x)"],
-  moduleNameMapper: {
-    "@lib(.*)": "<rootDir>/dist/mirage-umd",
-    "@miragejs/server": "<rootDir>/dist/mirage-umd"
-  }
-};
-
-let cjsBundle = {
-  displayName: "cjs bundle",
-  transformIgnorePatterns: ["<rootDir>/node_modules/(?!lodash-es)"],
-  setupFilesAfterEnv: ["jest-extended"],
-  testMatch: ["**/__tests__/integration/**/*-test.[jt]s?(x)"],
-  moduleNameMapper: {
-    "@lib(.*)": "<rootDir>/dist/mirage-cjs",
-    "@miragejs/server": "<rootDir>/dist/mirage-cjs"
-  }
-};
+// let esmBundle = {
+//   displayName: "esm bundle",
+//   transformIgnorePatterns: ["<rootDir>/node_modules/(?!lodash-es)"],
+//   setupFilesAfterEnv: ["jest-extended"],
+//   testMatch: ["**/__tests__/integration/**/*-test.[jt]s?(x)"],
+//   moduleNameMapper: {
+//     "@lib(.*)": "<rootDir>/dist/mirage-ems",
+//     "@miragejs/server": "<rootDir>/dist/mirage-ems"
+//   }
+// };
+//
+// let umdBundle = {
+//   displayName: "umd bundle",
+//   setupFilesAfterEnv: ["jest-extended"],
+//   testMatch: ["**/__tests__/integration/**/*-test.[jt]s?(x)"],
+//   moduleNameMapper: {
+//     "@lib(.*)": "<rootDir>/dist/mirage-umd",
+//     "@miragejs/server": "<rootDir>/dist/mirage-umd"
+//   }
+// };
+//
+// let cjsBundle = {
+//   displayName: "cjs bundle",
+//   transformIgnorePatterns: ["<rootDir>/node_modules/(?!lodash-es)"],
+//   setupFilesAfterEnv: ["jest-extended"],
+//   testMatch: ["**/__tests__/integration/**/*-test.[jt]s?(x)"],
+//   moduleNameMapper: {
+//     "@lib(.*)": "<rootDir>/dist/mirage-cjs",
+//     "@miragejs/server": "<rootDir>/dist/mirage-cjs"
+//   }
+// };
 
 // let eslint = {
 //   displayName: "lint",
@@ -52,5 +52,6 @@ let cjsBundle = {
 // };
 
 module.exports = {
-  projects: [browser, esmBundle, cjsBundle, umdBundle]
+  // Only browser for now, but add back in bundles soon
+  projects: [browser]
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,3 @@
-// Polyfill for ES2015+ environment (https://babeljs.io/docs/en/babel-polyfill/)
-import "core-js/stable";
-import "regenerator-runtime/runtime";
-
 import Factory from "./factory";
 import IdentityManager from "./identity-manager";
 import association from "./association";

--- a/lib/server.js
+++ b/lib/server.js
@@ -563,7 +563,7 @@ export default class Server {
 
       let missingKeys = camelizedArgs.filter(key => !fixtures[key]);
       if (missingKeys.length) {
-        throw new Error(`Fixtures not found: ${missingKeys.join(', ')}`);
+        throw new Error(`Fixtures not found: ${missingKeys.join(", ")}`);
       }
 
       fixtures = pick(fixtures, ...camelizedArgs);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "@miragejs/server",
   "version": "0.1.13",
   "description": "A client-side server to help you build, test and demo your JavaScript app",
-  "main": "dist/index.js",
+  "main": "index.js",
+  "module": "dist/mirage-esm.js",
   "keywords": [
     "pretender",
     "prototype",

--- a/rollup.test.config.js
+++ b/rollup.test.config.js
@@ -1,4 +1,3 @@
-/* global process */
 import path from "path";
 import babel from "rollup-plugin-babel";
 import resolve from "rollup-plugin-node-resolve";

--- a/shims/pretender-node.js
+++ b/shims/pretender-node.js
@@ -1,0 +1,1 @@
+export default function() {}


### PR DESCRIPTION
This needs a check-in / review.

* Changes the rollup config to build for esm, cjs, and umd. `package.json` `module` will point at the esm, and `main` will point at index, which redirects to cjs. 

* Jest will run the integration tests against each of the bundles. These tests will fail, because they're importing files from lib. We can change these to use all public API. Probably should not enable these tests right now.

