### PR TITLE
Use real pretender in package.json's browser field

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "A client-side server to help you build, test and demo your JavaScript app",
   "main": "index.js",
   "module": "dist/mirage-esm.js",
-  "browser": "dist/mirage-umd.js",
+  "browser": {
+    "./shims/pretender-node.js": "pretender"
+  },
   "keywords": [
     "pretender",
     "prototype",


### PR DESCRIPTION
This way build tools consuming the cjs module will be have a real pretender, since they're building for the web.