### PR TITLE
Remove assignment to Parent because ugly thinks its a variable that's never used

### DIFF
--- a/lib/utils/extend.js
+++ b/lib/utils/extend.js
@@ -4,9 +4,7 @@ import has from "lodash.has";
   @hide
 */
 export default function extend(protoProps, staticProps) {
-  let Parent = this;
-
-  class Child extends Parent {
+  class Child extends this {
     constructor(...args) {
       super(...args);
       // The constructor function for the new subclass is optionally defined by you
@@ -19,7 +17,7 @@ export default function extend(protoProps, staticProps) {
 
   // Add static properties to the constructor function, if supplied.
 
-  Object.assign(Child, Parent, staticProps);
+  Object.assign(Child, this, staticProps);
 
   // Add prototype properties (instance properties) to the subclass,
   // if supplied.


### PR DESCRIPTION
When the UMD build is uglified, uglify removes assignment which causes Parent to become undefined. This change prevents uglify from removing the assignment by proactively removing the assignment.