### PR TITLE
[WIP] Start testing all builds

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,5 @@
 let internal = {
   displayName: "internal",
-  transformIgnorePatterns: ["<rootDir>/node_modules/(?!lodash)"],
   setupFilesAfterEnv: ["jest-extended"],
   testMatch: ["**/__tests__/internal/**/*-test.[jt]s?(x)"],
   moduleNameMapper: {
@@ -9,43 +8,62 @@ let internal = {
   }
 };
 
-// let esmBundle = {
-//   displayName: "esm bundle",
-//   transformIgnorePatterns: ["<rootDir>/node_modules/(?!lodash)"],
-//   setupFilesAfterEnv: ["jest-extended"],
-//   testMatch: ["**/__tests__/integration/**/*-test.[jt]s?(x)"],
-//   moduleNameMapper: {
-//     "@lib(.*)": "<rootDir>/dist/mirage-ems",
-//     "@miragejs/server": "<rootDir>/dist/mirage-ems"
-//   }
-// };
-//
-// let umdBundle = {
-//   displayName: "umd bundle",
-//   setupFilesAfterEnv: ["jest-extended"],
-//   testMatch: ["**/__tests__/integration/**/*-test.[jt]s?(x)"],
-//   moduleNameMapper: {
-//     "@lib(.*)": "<rootDir>/dist/mirage-umd",
-//     "@miragejs/server": "<rootDir>/dist/mirage-umd"
-//   }
-// };
-//
-// let cjsBundle = {
-//   displayName: "cjs bundle",
-//   transformIgnorePatterns: ["<rootDir>/node_modules/(?!lodash)"],
-//   setupFilesAfterEnv: ["jest-extended"],
-//   testMatch: ["**/__tests__/integration/**/*-test.[jt]s?(x)"],
-//   moduleNameMapper: {
-//     "@lib(.*)": "<rootDir>/dist/mirage-cjs",
-//     "@miragejs/server": "<rootDir>/dist/mirage-cjs"
-//   }
-// };
+let browserEnvironmentConsumingEsm = {
+  displayName: "browserEnvironmentConsumingEsm",
+  testEnvironment: "jsdom",
+  setupFilesAfterEnv: ["jest-extended"],
+  testMatch: [
+    "**/__tests__/external/shared/**/*-test.[jt]s?(x)",
+    "**/__tests__/external/browser-only/**/*-test.[jt]s?(x)"
+  ],
+  moduleNameMapper: {
+    "@miragejs/server": "<rootDir>/dist/mirage-esm.js"
+  }
+};
+
+let nodeEnvironmentConsumingEsm = {
+  displayName: "browserEnvironmentConsumingEsm",
+  testEnvironment: "node",
+  setupFilesAfterEnv: ["jest-extended"],
+  testMatch: [
+    "**/__tests__/external/shared/**/*-test.[jt]s?(x)",
+    "**/__tests__/external/node-only/**/*-test.[jt]s?(x)"
+  ],
+  moduleNameMapper: {
+    "@miragejs/server": "<rootDir>/dist/mirage-esm.js"
+  }
+};
+
+let browserEnvironmentConsumingUmd = {
+  displayName: "browserEnvironmentConsumingUmd",
+  testEnvironment: "jsdom",
+  setupFilesAfterEnv: ["jest-extended"],
+  testMatch: [
+    "**/__tests__/external/shared/**/*-test.[jt]s?(x)",
+    "**/__tests__/external/browser-only/**/*-test.[jt]s?(x)"
+  ],
+  moduleNameMapper: {
+    "@miragejs/server": "<rootDir>/dist/mirage-umd"
+  }
+};
+
+let nodeEnvironmentConsumingUmd = {
+  displayName: "nodeEnvironmentConsumingUmd",
+  testEnvironment: "node",
+  setupFilesAfterEnv: ["jest-extended"],
+  testMatch: [
+    "**/__tests__/external/shared/**/*-test.[jt]s?(x)",
+    "**/__tests__/external/node-only/**/*-test.[jt]s?(x)"
+  ],
+  moduleNameMapper: {
+    "@miragejs/server": "<rootDir>/dist/mirage-umd"
+  }
+};
 
 // External API, Create React App-like environment.
 let browserEnvironmentConsumingCjs = {
   displayName: "browserEnvironmentConsumingCjs",
   testEnvironment: "jsdom",
-  transformIgnorePatterns: ["<rootDir>/node_modules/(?!lodash)"],
   setupFilesAfterEnv: ["jest-extended"],
   testMatch: [
     "**/__tests__/external/shared/**/*-test.[jt]s?(x)",
@@ -60,7 +78,6 @@ let browserEnvironmentConsumingCjs = {
 let nodeEnvironmentConsumingCjs = {
   displayName: "nodeEnvironmentConsumingCjs",
   testEnvironment: "node",
-  transformIgnorePatterns: ["<rootDir>/node_modules/(?!lodash)"],
   setupFilesAfterEnv: ["jest-extended"],
   testMatch: [
     "**/__tests__/external/shared/**/*-test.[jt]s?(x)",
@@ -71,40 +88,14 @@ let nodeEnvironmentConsumingCjs = {
   }
 };
 
-// From Ryan's PR. Run all tests in Node. (Lots will fail.)
-// let node = {
-//   displayName: "node",
-//   transformIgnorePatterns: ["<rootDir>/node_modules/(?!lodash)"],
-//   setupFilesAfterEnv: ["jest-extended"],
-//   testEnvironment: "node",
-//   testMatch: ["**/__tests__/**/*-test.[jt]s?(x)"],
-//   testPathIgnorePatterns: [
-//     "<rootDir>/__tests__/browser-only/",
-//     "/node_modules/"
-//   ],
-//   moduleNameMapper: {
-//     "@lib(.*)": "<rootDir>/lib$1",
-//     "@miragejs/server": "<rootDir>/lib/index",
-//     pretender: "<rootDir>/shims/pretender-node.js"
-//   }
-// };
-
-// let eslint = {
-//   displayName: "lint",
-//   runner: "jest-runner-eslint",
-//   cliOptions: {
-//     config: "./.eslintrc.js"
-//   },
-//   // testMatch: ["<rootDir>/__tests__/**/*.js", "<rootDir>/lib/**/*.js"]
-//   testMatch: ["<rootDir>/lib/response.js"]
-// };
-
 module.exports = {
-  // Only browser for now, but add back in bundles soon
-  // projects: [browser]
   projects: [
-    internal,
-    browserEnvironmentConsumingCjs,
-    nodeEnvironmentConsumingCjs
+    // internal,
+    // browserEnvironmentConsumingCjs,
+    // nodeEnvironmentConsumingCjs,
+    // browserEnvironmentConsumingEsm,
+    nodeEnvironmentConsumingEsm
+    // browserEnvironmentConsumingUmd,
+    // nodeEnvironmentConsumingUmd
   ]
 };


### PR DESCRIPTION
Very much a work in progress but I wanted to push so we can discuss.

A few questions came up while doing this:

1) Patching pretender to no-op in umd makes sense, since umd is the entire server with no external dependencies. Also makes sense for cjs+node, since pretender doesn't work there we're forced to patch it because otherwise the consuming app crashes. What about cjs+browser, or esm? These environments might want to import their own pretender, or have a resolution to a specific pretender version. 

2) I am not sure how to rewrite pretender in esm. Hit a wall.

I could see us spending a lot of time trying to answer these questions, so it might be best to setup testing scenarios that reflect how specific tooling consumes these builds. 