### PR TITLE
Add back in corejs@3

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "ci": "run-s lint test"
   },
   "dependencies": {
+    "core-js": "3",
     "inflected": "^2.0.4",
     "lodash.assign": "^4.2.0",
     "lodash.camelcase": "^4.3.0",
@@ -50,9 +51,9 @@
     "lodash.map": "^4.6.0",
     "lodash.mapvalues": "^4.6.0",
     "lodash.pick": "^4.4.0",
+    "lodash.snakecase": "^4.1.1",
     "lodash.uniq": "^4.5.0",
     "lodash.uniqby": "^4.7.0",
-    "lodash.snakecase": "^4.1.1",
     "lodash.values": "^4.3.0",
     "pretender": "3.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1486,6 +1486,11 @@ core-js-pure@3.1.4:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.1.4.tgz#5fa17dc77002a169a3566cc48dc774d2e13e3769"
   integrity sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA==
 
+core-js@3:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.2.1.tgz#cd41f38534da6cc59f7db050fe67307de9868b09"
+  integrity sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"


### PR DESCRIPTION
We wrongfully removed corejs in https://github.com/miragejs/server/pull/113
because we thought using the options to our rollup babel plugin to enable
the polyfill didn't need it as a dependency. We were wrong!