### PR TITLE
refactor: reduce loop count during model setup

### DIFF
--- a/lib/orm/model.js
+++ b/lib/orm/model.js
@@ -81,7 +81,7 @@ class Model {
       @property attrs
       @public
     */
-    this.attrs = undefined;
+    this.attrs = {};
 
     attrs = attrs || {};
 
@@ -161,8 +161,8 @@ class Model {
 
     Object.keys(attrs).forEach(function(attr) {
       if (
-        this.associationKeys.indexOf(attr) === -1 &&
-        this.associationIdKeys.indexOf(attr) === -1
+        !this.associationKeys.includes(attr) &&
+        !this.associationIdKeys.includes(attr)
       ) {
         this._definePlainAttribute(attr);
       }
@@ -523,33 +523,22 @@ class Model {
   _setupAttrs(attrs) {
     this._validateAttrs(attrs);
 
-    // Filter out association keys
-    let hash = Object.keys(attrs).reduce((memo, key) => {
-      if (
-        this.associationKeys.indexOf(key) === -1 &&
-        this.associationIdKeys.indexOf(key) === -1
-      ) {
-        memo[key] = attrs[key];
-      }
-      return memo;
-    }, {});
-
     // Ensure fks are there
-    this.fks.map(function(fk) {
-      hash[fk] = attrs[fk] !== undefined ? attrs[fk] : null;
+    this.fks.forEach(fk => {
+      this.attrs[fk] = attrs[fk] !== undefined ? attrs[fk] : null;
     });
 
-    this.attrs = hash;
+    Object.keys(attrs).forEach(attr => {
+      const isAssociation =
+        this.associationKeys.includes(attr) ||
+        this.associationIdKeys.includes(attr);
 
-    // define plain getter/setters for non-association keys
-    Object.keys(hash).forEach(function(attr) {
-      if (
-        this.associationKeys.indexOf(attr) === -1 &&
-        this.associationIdKeys.indexOf(attr) === -1
-      ) {
+      if (!isAssociation) {
+        this.attrs[attr] = attrs[attr];
+        // define plain getter/setters for non-association keys
         this._definePlainAttribute(attr);
       }
-    }, this);
+    });
   }
 
   /**
@@ -595,34 +584,22 @@ class Model {
     @hide
    */
   _setupRelationships(attrs) {
-    let foreignKeysHash = Object.keys(attrs).reduce((memo, attr) => {
-      if (
-        this.associationIdKeys.indexOf(attr) > -1 ||
-        this.fks.indexOf(attr) > -1
-      ) {
-        memo[attr] = attrs[attr];
-      }
-      return memo;
-    }, {});
+    Object.keys(attrs).forEach(attr => {
+      const value = attrs[attr];
+      const isFk =
+        this.associationIdKeys.includes(attr) || this.fks.includes(attr);
+      const isAssociation = this.associationKeys.includes(attr);
 
-    Object.keys(foreignKeysHash).forEach(function(attr) {
-      let fk = foreignKeysHash[attr];
-      if (fk !== undefined && fk !== null) {
-        this._validateForeignKeyExistsInDatabase(attr, fk);
+      if (isFk) {
+        if (value !== undefined && value !== null) {
+          this._validateForeignKeyExistsInDatabase(attr, value);
+        }
+        this.attrs[attr] = value;
       }
-
-      this.attrs[attr] = fk;
-    }, this);
-
-    let associationKeysHash = Object.keys(attrs).reduce((memo, attr) => {
-      if (this.associationKeys.indexOf(attr) > -1) {
-        memo[attr] = attrs[attr];
+      if (isAssociation) {
+        this[attr] = value;
       }
-      return memo;
-    }, {});
-    Object.keys(associationKeysHash).forEach(function(attr) {
-      this[attr] = associationKeysHash[attr];
-    }, this);
+    });
   }
 
   /**
@@ -631,53 +608,52 @@ class Model {
     @hide
    */
   _validateAttrs(attrs) {
-    // Verify attrs passed in for associations are actually associations
-    Object.keys(attrs)
-      .filter(key => this.associationKeys.includes(key))
-      .forEach(key => {
-        let value = attrs[key];
-        let association = this.associationFor(key);
-        let isNull = value === null;
+    Object.keys(attrs).forEach(key => {
+      let value = attrs[key];
 
-        if (association instanceof HasMany) {
-          let isCollection =
-            value instanceof Collection ||
-            value instanceof PolymorphicCollection;
-          let isArrayOfModels =
-            Array.isArray(value) && value.every(item => item instanceof Model);
-
-          assert(
-            isCollection || isArrayOfModels || isNull,
-            `You're trying to create a ${this.modelName} model and you passed in "${value}" under the ${key} key, but that key is a HasMany relationship. You must pass in a Collection, PolymorphicCollection, array of Models, or null.`
-          );
-        } else if (association instanceof BelongsTo) {
-          assert(
-            value instanceof Model || isNull,
-            `You're trying to create a ${this.modelName} model and you passed in "${value}" under the ${key} key, but that key is a BelongsTo relationship. You must pass in a Model or null.`
-          );
-        }
-      });
-
-    // Verify attrs passed in for association foreign keys are actually fks
-    Object.keys(attrs)
-      .filter(key => this.associationIdKeys.includes(key))
-      .forEach(key => {
-        let value = attrs[key];
-
-        if (key.match(/Ids$/)) {
-          let isArray = Array.isArray(value);
+      // Verify attrs passed in for associations are actually associations
+      {
+        if (this.associationKeys.includes(key)) {
+          let association = this.associationFor(key);
           let isNull = value === null;
-          assert(
-            isArray || isNull,
-            `You're trying to create a ${this.modelName} model and you passed in "${value}" under the ${key} key, but that key is a foreign key for a HasMany relationship. You must pass in an array of ids or null.`
-          );
-        }
-      });
 
-    // Verify no undefined associations are passed in
-    Object.keys(attrs)
-      .filter(key => {
-        let value = attrs[key];
+          if (association instanceof HasMany) {
+            let isCollection =
+              value instanceof Collection ||
+              value instanceof PolymorphicCollection;
+            let isArrayOfModels =
+              Array.isArray(value) &&
+              value.every(item => item instanceof Model);
+
+            assert(
+              isCollection || isArrayOfModels || isNull,
+              `You're trying to create a ${this.modelName} model and you passed in "${value}" under the ${key} key, but that key is a HasMany relationship. You must pass in a Collection, PolymorphicCollection, array of Models, or null.`
+            );
+          } else if (association instanceof BelongsTo) {
+            assert(
+              value instanceof Model || isNull,
+              `You're trying to create a ${this.modelName} model and you passed in "${value}" under the ${key} key, but that key is a BelongsTo relationship. You must pass in a Model or null.`
+            );
+          }
+        }
+      }
+
+      // Verify attrs passed in for association foreign keys are actually fks
+      {
+        if (this.associationIdKeys.includes(key)) {
+          if (key.endsWith("Ids")) {
+            let isArray = Array.isArray(value);
+            let isNull = value === null;
+            assert(
+              isArray || isNull,
+              `You're trying to create a ${this.modelName} model and you passed in "${value}" under the ${key} key, but that key is a foreign key for a HasMany relationship. You must pass in an array of ids or null.`
+            );
+          }
+        }
+      }
+
+      // Verify no undefined associations are passed in
+      {
         let isModelOrCollection =
           value instanceof Model ||
           value instanceof Collection ||
@@ -687,18 +663,18 @@ class Model {
           value.length &&
           value.every(item => item instanceof Model);
 
-        return isModelOrCollection || isArrayOfModels;
-      })
-      .forEach(key => {
-        let modelOrCollection = attrs[key];
+        if (isModelOrCollection || isArrayOfModels) {
+          let modelOrCollection = attrs[key];
 
-        assert(
-          this.associationKeys.indexOf(key) > -1,
-          `You're trying to create a ${
-            this.modelName
-          } model and you passed in a ${modelOrCollection.toString()} under the ${key} key, but you haven't defined that key as an association on your model.`
-        );
-      });
+          assert(
+            this.associationKeys.includes(key),
+            `You're trying to create a ${
+              this.modelName
+            } model and you passed in a ${modelOrCollection.toString()} under the ${key} key, but you haven't defined that key as an association on your model.`
+          );
+        }
+      }
+    });
   }
 
   /**
@@ -1015,7 +991,7 @@ class Model {
           );
         } else {
           newId = ownerId;
-          alreadyAssociatedWith = newIdsForInverse.indexOf(ownerId) !== -1;
+          alreadyAssociatedWith = newIdsForInverse.includes(ownerId);
         }
 
         if (!alreadyAssociatedWith) {


### PR DESCRIPTION
This reduces the amount of loops that are done during hydration when setting models up.

See example on how often `_setupAttrs` and `_setupRelationships` are called:

![20190915-100909](https://user-images.githubusercontent.com/1205444/64919543-88bdd600-d7ac-11e9-9c06-f2190850d58f.png)

This also replaces some `arr.indexOf()` calls with `arr.includes` as includes is already used elsewhere to check if an array includes an item).

**Note**: this has to rebased if the other PRs are merged.

I could also move all the changes into one bigger PR if that's easier to review.