### PR TITLE
Fix UMD build

### DIFF
--- a/__tests__/external/shared/factories/create-and-create-list-test.js
+++ b/__tests__/external/shared/factories/create-and-create-list-test.js
@@ -1,5 +1,5 @@
 import { Server, Model, Factory, hasMany, belongsTo } from "@miragejs/server";
-import { inflections } from "inflected";
+import { inflections, pluralize, singularize } from "inflected";
 
 // eslint-disable-next-line no-console
 let originalWarn = console.warn;
@@ -15,6 +15,10 @@ describe("External | Shared | Factories | create and createList", function() {
   let server, Contact, AmazingContact, Post, Author, Data;
 
   beforeEach(function() {
+    inflections("en", inflect => {
+      inflect.uncountable("data");
+    });
+
     Contact = Model.extend();
     AmazingContact = Model.extend();
     Post = Model.extend({
@@ -27,6 +31,7 @@ describe("External | Shared | Factories | create and createList", function() {
 
     server = new Server({
       environment: "test",
+      inflector: { pluralize, singularize },
       models: {
         contact: Contact,
         amazingContact: AmazingContact,
@@ -83,9 +88,6 @@ describe("External | Shared | Factories | create and createList", function() {
   test("create returns a Model instance if the Model name is uncountable", () => {
     expectNoWarning();
 
-    inflections("en", inflect => {
-      inflect.uncountable("data");
-    });
     let data = server.create("data");
 
     expect(data instanceof Data).toBeTruthy();
@@ -124,9 +126,6 @@ describe("External | Shared | Factories | create and createList", function() {
   test("createList returns Models if the model name is uncountable", () => {
     expectNoWarning();
 
-    inflections("en", inflect => {
-      inflect.uncountable("data");
-    });
     let data = server.createList("data", 1);
 
     expect(data[0] instanceof Data).toBeTruthy();

--- a/jest.config.js
+++ b/jest.config.js
@@ -65,18 +65,18 @@ let nodeEnvironmentConsumingCjs = {
 };
 
 // External API, script tag or Code Sandbox
-// let browserEnvironmentConsumingUmd = {
-//   displayName: "browserEnvironmentConsumingUmd",
-//   testEnvironment: "jsdom",
-//   setupFilesAfterEnv: ["jest-extended"],
-//   testMatch: [
-//     "**/__tests__/external/shared/**/*-test.[jt]s?(x)",
-//     "**/__tests__/external/browser-only/**/*-test.[jt]s?(x)"
-//   ],
-//   moduleNameMapper: {
-//     "@miragejs/server": "<rootDir>/dist/mirage-umd.js"
-//   }
-// };
+let browserEnvironmentConsumingUmd = {
+  displayName: "browserEnvironmentConsumingUmd",
+  testEnvironment: "jsdom",
+  setupFilesAfterEnv: ["jest-extended"],
+  testMatch: [
+    "**/__tests__/external/shared/**/*-test.[jt]s?(x)",
+    "**/__tests__/external/browser-only/**/*-test.[jt]s?(x)"
+  ],
+  moduleNameMapper: {
+    "@miragejs/server": "<rootDir>/dist/mirage-umd.js"
+  }
+};
 
 module.exports = {
   projects: [
@@ -84,7 +84,7 @@ module.exports = {
     browserEnvironmentConsumingEsm,
     nodeEnvironmentConsumingEsm,
     browserEnvironmentConsumingCjs,
-    nodeEnvironmentConsumingCjs
-    // browserEnvironmentConsumingUmd
+    nodeEnvironmentConsumingCjs,
+    browserEnvironmentConsumingUmd
   ]
 };

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@babel/preset-env": "7.6.0",
     "babel-eslint": "^10.0.2",
     "babel-jest": "^24.8.0",
+    "core-js": "3",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.3.0",
     "eslint-import-resolver-alias": "^1.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1484,6 +1484,11 @@ core-js-pure@3.1.4:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.1.4.tgz#5fa17dc77002a169a3566cc48dc774d2e13e3769"
   integrity sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA==
 
+core-js@3:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.2.1.tgz#cd41f38534da6cc59f7db050fe67307de9868b09"
+  integrity sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"


### PR DESCRIPTION
- adds corejs
- The inflection test in the create-and-create-list test module previously
  worked by configuring the `inflected` package in a global/mutable way.
  (This is actually the package's recommended way of configuring inflections.)
  But Mirage accepts a custom "inflector" if you just pass in a pluralize
  and singularize string.

  Since I wanted to also verify inflections could be customized for the UMD
  build, and the UMD build doesn't work with inflected's default customizations
  (since it's not referencing the global/imported version of that pacakge),
  it made sense to refactor these tests to have the "caller" pass in
  pluralize/singularize. That way, they'd work for all builds. It also
  better reflects how folks should actually customize Mirage inflections.