### PR TITLE
perf: use Set for association(Id)Keys

### DIFF
--- a/lib/orm/associations/belongs-to.js
+++ b/lib/orm/associations/belongs-to.js
@@ -76,8 +76,8 @@ export default class BelongsTo extends Association {
 
     // TODO: look how this is used. Are these necessary, seems like they could be gotten from the above?
     // Or we could use a single data structure to store this information?
-    modelPrototype.associationKeys.push(key);
-    modelPrototype.associationIdKeys.push(foreignKey);
+    modelPrototype.associationKeys.add(key);
+    modelPrototype.associationIdKeys.add(foreignKey);
 
     Object.defineProperty(modelPrototype, foreignKey, {
       /*

--- a/lib/orm/associations/has-many.js
+++ b/lib/orm/associations/has-many.js
@@ -81,8 +81,8 @@ export default class HasMany extends Association {
 
     // TODO: look how this is used. Are these necessary, seems like they could be gotten from the above?
     // Or we could use a single data structure to store this information?
-    modelPrototype.associationKeys.push(key);
-    modelPrototype.associationIdKeys.push(foreignKey);
+    modelPrototype.associationKeys.add(key);
+    modelPrototype.associationIdKeys.add(foreignKey);
 
     Object.defineProperty(modelPrototype, foreignKey, {
       /*

--- a/lib/orm/model.js
+++ b/lib/orm/model.js
@@ -161,8 +161,8 @@ class Model {
 
     Object.keys(attrs).forEach(function(attr) {
       if (
-        !this.associationKeys.includes(attr) &&
-        !this.associationIdKeys.includes(attr)
+        !this.associationKeys.has(attr) &&
+        !this.associationIdKeys.has(attr)
       ) {
         this._definePlainAttribute(attr);
       }
@@ -530,8 +530,7 @@ class Model {
 
     Object.keys(attrs).forEach(attr => {
       const isAssociation =
-        this.associationKeys.includes(attr) ||
-        this.associationIdKeys.includes(attr);
+        this.associationKeys.has(attr) || this.associationIdKeys.has(attr);
 
       if (!isAssociation) {
         this.attrs[attr] = attrs[attr];
@@ -586,9 +585,8 @@ class Model {
   _setupRelationships(attrs) {
     Object.keys(attrs).forEach(attr => {
       const value = attrs[attr];
-      const isFk =
-        this.associationIdKeys.includes(attr) || this.fks.includes(attr);
-      const isAssociation = this.associationKeys.includes(attr);
+      const isFk = this.associationIdKeys.has(attr) || this.fks.includes(attr);
+      const isAssociation = this.associationKeys.has(attr);
 
       if (isFk) {
         if (value !== undefined && value !== null) {
@@ -613,7 +611,7 @@ class Model {
 
       // Verify attrs passed in for associations are actually associations
       {
-        if (this.associationKeys.includes(key)) {
+        if (this.associationKeys.has(key)) {
           let association = this.associationFor(key);
           let isNull = value === null;
 
@@ -640,7 +638,7 @@ class Model {
 
       // Verify attrs passed in for association foreign keys are actually fks
       {
-        if (this.associationIdKeys.includes(key)) {
+        if (this.associationIdKeys.has(key)) {
           if (key.endsWith("Ids")) {
             let isArray = Array.isArray(value);
             let isNull = value === null;
@@ -667,7 +665,7 @@ class Model {
           let modelOrCollection = attrs[key];
 
           assert(
-            this.associationKeys.includes(key),
+            this.associationKeys.has(key),
             `You're trying to create a ${
               this.modelName
             } model and you passed in a ${modelOrCollection.toString()} under the ${key} key, but you haven't defined that key as an association on your model.`

--- a/lib/orm/schema.js
+++ b/lib/orm/schema.js
@@ -89,8 +89,8 @@ export default class Schema {
     // Set up associations
     ModelClass.prototype.hasManyAssociations = {}; // a registry of the model's hasMany associations. Key is key from model definition, value is association instance itself
     ModelClass.prototype.belongsToAssociations = {}; // a registry of the model's belongsTo associations. Key is key from model definition, value is association instance itself
-    ModelClass.prototype.associationKeys = []; // ex: address.user, user.addresses
-    ModelClass.prototype.associationIdKeys = []; // ex: address.user_id, user.address_ids
+    ModelClass.prototype.associationKeys = new Set(); // ex: address.user, user.addresses
+    ModelClass.prototype.associationIdKeys = new Set(); // ex: address.user_id, user.address_ids
     ModelClass.prototype.dependentAssociations = []; // a registry of associations that depend on this model, needed for deletion cleanup.
 
     let fksAddedFromThisModel = {};

--- a/lib/serializers/json-api-serializer.js
+++ b/lib/serializers/json-api-serializer.js
@@ -307,7 +307,9 @@ class JSONAPISerializer extends Serializer {
   }
 
   _maybeAddRelationshipsToResourceObjectForModel(hash, model) {
-    let relationships = model.associationKeys.reduce((relationships, key) => {
+    const relationships = {};
+
+    model.associationKeys.forEach(key => {
       let relationship = model[key];
       let relationshipKey = this.keyForRelationship(key);
       let relationshipHash = {};
@@ -343,9 +345,7 @@ class JSONAPISerializer extends Serializer {
       if (!isEmpty(relationshipHash)) {
         relationships[relationshipKey] = relationshipHash;
       }
-
-      return relationships;
-    }, {});
+    });
 
     if (!isEmpty(relationships)) {
       hash.relationships = relationships;
@@ -448,7 +448,7 @@ class JSONAPISerializer extends Serializer {
         let relationshipKey = relationshipKeys[0];
         let graphRelationshipKey = relationshipKey;
         let normalizedRelationshipKey = camelize(relationshipKey);
-        let hasAssociation = model.associationKeys.includes(
+        let hasAssociation = model.associationKeys.has(
           normalizedRelationshipKey
         );
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -725,8 +725,9 @@ export default class Server {
 
     let list = [];
 
+    const buildArgs = [type, ...traitsAndOverrides];
     for (let i = 0; i < amount; i++) {
-      list.push(this.build(type, ...traitsAndOverrides));
+      list.push(this.build.apply(this, buildArgs));
     }
 
     return list;
@@ -886,8 +887,10 @@ export default class Server {
       : `_${this.inflector.pluralize(type)}`;
     let collection = this.db[collectionName];
 
+    const createArguments = [type, ...traitsAndOverrides, collection];
+
     for (let i = 0; i < amount; i++) {
-      list.push(this.create(type, ...traitsAndOverrides, collection));
+      list.push(this.create.apply(this, createArguments));
     }
 
     return list;


### PR DESCRIPTION
Both `associationKeys` and `associationIdKeys` are primarily used to check if a key is included in them.
They're looked up repeatedly when setting up attrs.

I've changed them to a Set because:
* `set.has` should be something like closes to O(1)  (see also [microbenchmark](http://jsben.ch/TFCDD)`*`)
* Set is still [supported by IE11](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#Browser_compatibility)

This PR also extracts the static arguments from server.create/createList as they never change on each invocation.

`*` = microbenchmarks are never perfect

Using https://gist.github.com/makepanic/241013f4dd94d6064d046642d60c43d2 to benchmark this change, I'm getting:

// master
setup x 13.14 ops/sec ±16.22% (24 runs sampled)
setup x 12.84 ops/sec ±17.21% (24 runs sampled)

// use-set
setup x 13.29 ops/sec ±17.00% (24 runs sampled)
setup x 13.22 ops/sec ±16.53% (24 runs sampled)

This doesn't seem to be a big improvement though. It's up to you if you want it.