### PR TITLE
perf(model): remove attr iterations when creating a model instance

### DIFF
--- a/lib/orm/model.js
+++ b/lib/orm/model.js
@@ -85,8 +85,18 @@ class Model {
 
     attrs = attrs || {};
 
-    this._setupAttrs(attrs);
-    this._setupRelationships(attrs);
+    // Ensure fks are there
+    this.fks.forEach(fk => {
+      this.attrs[fk] = attrs[fk] !== undefined ? attrs[fk] : null;
+    });
+
+    Object.keys(attrs).forEach(name => {
+      const value = attrs[name];
+
+      this._validateAttr(name, value);
+      this._setupAttr(name, value);
+      this._setupRelationship(name, value);
+    });
 
     return this;
   }
@@ -515,29 +525,21 @@ class Model {
   /**
     model.attrs represents the persistable attributes, i.e. your db
     table fields.
-    @method _setupAttrs
-    @param attrs
+    @method _setupAttr
+    @param attr
+    @param value
     @private
     @hide
    */
-  _setupAttrs(attrs) {
-    this._validateAttrs(attrs);
+  _setupAttr(attr, value) {
+    const isAssociation =
+      this.associationKeys.has(attr) || this.associationIdKeys.has(attr);
 
-    // Ensure fks are there
-    this.fks.forEach(fk => {
-      this.attrs[fk] = attrs[fk] !== undefined ? attrs[fk] : null;
-    });
-
-    Object.keys(attrs).forEach(attr => {
-      const isAssociation =
-        this.associationKeys.has(attr) || this.associationIdKeys.has(attr);
-
-      if (!isAssociation) {
-        this.attrs[attr] = attrs[attr];
-        // define plain getter/setters for non-association keys
-        this._definePlainAttribute(attr);
-      }
-    });
+    if (!isAssociation) {
+      this.attrs[attr] = value;
+      // define plain getter/setters for non-association keys
+      this._definePlainAttribute(attr);
+    }
   }
 
   /**
@@ -577,102 +579,95 @@ class Model {
    *
     We validate foreign keys during instantiation.
    *
-    @method _setupRelationships
-    @param attrs
+    @method _setupRelationship
+    @param attr
+    @param value
     @private
     @hide
    */
-  _setupRelationships(attrs) {
-    Object.keys(attrs).forEach(attr => {
-      const value = attrs[attr];
-      const isFk = this.associationIdKeys.has(attr) || this.fks.includes(attr);
-      const isAssociation = this.associationKeys.has(attr);
+  _setupRelationship(attr, value) {
+    const isFk = this.associationIdKeys.has(attr) || this.fks.includes(attr);
+    const isAssociation = this.associationKeys.has(attr);
 
-      if (isFk) {
-        if (value !== undefined && value !== null) {
-          this._validateForeignKeyExistsInDatabase(attr, value);
-        }
-        this.attrs[attr] = value;
+    if (isFk) {
+      if (value !== undefined && value !== null) {
+        this._validateForeignKeyExistsInDatabase(attr, value);
       }
-      if (isAssociation) {
-        this[attr] = value;
-      }
-    });
+      this.attrs[attr] = value;
+    }
+    if (isAssociation) {
+      this[attr] = value;
+    }
   }
 
   /**
-    @method _validateAttrs
+    @method _validateAttr
     @private
     @hide
    */
-  _validateAttrs(attrs) {
-    Object.keys(attrs).forEach(key => {
-      let value = attrs[key];
+  _validateAttr(key, value) {
+    // Verify attr passed in for associations is actually an association
+    {
+      if (this.associationKeys.has(key)) {
+        let association = this.associationFor(key);
+        let isNull = value === null;
 
-      // Verify attrs passed in for associations are actually associations
-      {
-        if (this.associationKeys.has(key)) {
-          let association = this.associationFor(key);
-          let isNull = value === null;
-
-          if (association instanceof HasMany) {
-            let isCollection =
-              value instanceof Collection ||
-              value instanceof PolymorphicCollection;
-            let isArrayOfModels =
-              Array.isArray(value) &&
-              value.every(item => item instanceof Model);
-
-            assert(
-              isCollection || isArrayOfModels || isNull,
-              `You're trying to create a ${this.modelName} model and you passed in "${value}" under the ${key} key, but that key is a HasMany relationship. You must pass in a Collection, PolymorphicCollection, array of Models, or null.`
-            );
-          } else if (association instanceof BelongsTo) {
-            assert(
-              value instanceof Model || isNull,
-              `You're trying to create a ${this.modelName} model and you passed in "${value}" under the ${key} key, but that key is a BelongsTo relationship. You must pass in a Model or null.`
-            );
-          }
-        }
-      }
-
-      // Verify attrs passed in for association foreign keys are actually fks
-      {
-        if (this.associationIdKeys.has(key)) {
-          if (key.endsWith("Ids")) {
-            let isArray = Array.isArray(value);
-            let isNull = value === null;
-            assert(
-              isArray || isNull,
-              `You're trying to create a ${this.modelName} model and you passed in "${value}" under the ${key} key, but that key is a foreign key for a HasMany relationship. You must pass in an array of ids or null.`
-            );
-          }
-        }
-      }
-
-      // Verify no undefined associations are passed in
-      {
-        let isModelOrCollection =
-          value instanceof Model ||
-          value instanceof Collection ||
-          value instanceof PolymorphicCollection;
-        let isArrayOfModels =
-          Array.isArray(value) &&
-          value.length &&
-          value.every(item => item instanceof Model);
-
-        if (isModelOrCollection || isArrayOfModels) {
-          let modelOrCollection = attrs[key];
+        if (association instanceof HasMany) {
+          let isCollection =
+            value instanceof Collection ||
+            value instanceof PolymorphicCollection;
+          let isArrayOfModels =
+            Array.isArray(value) && value.every(item => item instanceof Model);
 
           assert(
-            this.associationKeys.has(key),
-            `You're trying to create a ${
-              this.modelName
-            } model and you passed in a ${modelOrCollection.toString()} under the ${key} key, but you haven't defined that key as an association on your model.`
+            isCollection || isArrayOfModels || isNull,
+            `You're trying to create a ${this.modelName} model and you passed in "${value}" under the ${key} key, but that key is a HasMany relationship. You must pass in a Collection, PolymorphicCollection, array of Models, or null.`
+          );
+        } else if (association instanceof BelongsTo) {
+          assert(
+            value instanceof Model || isNull,
+            `You're trying to create a ${this.modelName} model and you passed in "${value}" under the ${key} key, but that key is a BelongsTo relationship. You must pass in a Model or null.`
           );
         }
       }
-    });
+    }
+
+    // Verify attrs passed in for association foreign keys are actually fks
+    {
+      if (this.associationIdKeys.has(key)) {
+        if (key.endsWith("Ids")) {
+          let isArray = Array.isArray(value);
+          let isNull = value === null;
+          assert(
+            isArray || isNull,
+            `You're trying to create a ${this.modelName} model and you passed in "${value}" under the ${key} key, but that key is a foreign key for a HasMany relationship. You must pass in an array of ids or null.`
+          );
+        }
+      }
+    }
+
+    // Verify no undefined associations are passed in
+    {
+      let isModelOrCollection =
+        value instanceof Model ||
+        value instanceof Collection ||
+        value instanceof PolymorphicCollection;
+      let isArrayOfModels =
+        Array.isArray(value) &&
+        value.length &&
+        value.every(item => item instanceof Model);
+
+      if (isModelOrCollection || isArrayOfModels) {
+        let modelOrCollection = value;
+
+        assert(
+          this.associationKeys.has(key),
+          `You're trying to create a ${
+            this.modelName
+          } model and you passed in a ${modelOrCollection.toString()} under the ${key} key, but you haven't defined that key as an association on your model.`
+        );
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
This removes the times mirage iterates over model attributes during setup.

Before it iterated over n attrs:

* 2x in `_setupAttrs`
* 1x in `_setupRelationships`

This doesn't seem that much but a model instance is created all the time due to [hydration](https://github.com/miragejs/server/blob/master/lib/orm/schema.js#L537).

This PR changes the behavior to only iterate once over all attrs.

This will also allow further optimization to skip relationship setup if the attr is an attribute (I'm not sure if mirage allows that though).

Using https://gist.github.com/makepanic/241013f4dd94d6064d046642d60c43d2 to benchmark this change, I'm getting:

// master
setup x 13.14 ops/sec ±16.22% (24 runs sampled)
setup x 12.84 ops/sec ±17.21% (24 runs sampled)

// model-cycles
setup x 13.32 ops/sec ±16.96% (24 runs sampled)
setup x 13.45 ops/sec ±17.09% (25 runs sampled)

(as usual benchmarks might be misleading)