### PR TITLE
perf: don't always recomputed modelClass from path

### DIFF
--- a/lib/route-handlers/base.js
+++ b/lib/route-handlers/base.js
@@ -2,7 +2,7 @@ import assert from "../assert";
 import { camelize, dasherize } from "../utils/inflector";
 import HasMany from "../orm/associations/has-many";
 
-const PATH_VAR_REGEXP = /^:/;
+const pathModelClassCache = {};
 
 /**
   @hide
@@ -12,19 +12,25 @@ export default class BaseRouteHandler {
     if (!fullPath) {
       return;
     }
-    let path = fullPath.split("/");
-    let lastPath;
-    while (path.length > 0) {
-      lastPath = path.splice(-1)[0];
-      if (lastPath && !PATH_VAR_REGEXP.test(lastPath)) {
-        break;
-      }
-    }
-    let modelName = dasherize(
-      camelize(this._container.inflector.singularize(lastPath))
-    );
 
-    return modelName;
+    if (typeof pathModelClassCache[fullPath] !== "string") {
+      let path = fullPath.split("/");
+      let lastPath;
+
+      for (let i = path.length - 1; i >= 0; i--) {
+        const segment = path[i];
+        if (segment[0] !== ":") {
+          lastPath = segment;
+          break;
+        }
+      }
+
+      pathModelClassCache[fullPath] = dasherize(
+        camelize(this._container.inflector.singularize(lastPath))
+      );
+    }
+
+    return pathModelClassCache[fullPath];
   }
 
   _getIdForRequest(request, jsonApiDoc) {


### PR DESCRIPTION
This caches the model name when extracting it from a full path.
This isn't really happen often during one test but always during setup.

The PR also adjusts the mechanism to find the last non variable path to avoid array mutations.