### PR TITLE
route-handlers/shorthands: Return 404 from PUT/DELETE if model can't be found

### DIFF
--- a/lib/route-handlers/shorthands/delete.js
+++ b/lib/route-handlers/shorthands/delete.js
@@ -1,6 +1,7 @@
 import assert from "../../assert";
 import BaseShorthandRouteHandler from "./base";
 import { camelize } from "../../utils/inflector";
+import Response from "../../response";
 
 /**
  * @hide
@@ -21,7 +22,12 @@ export default class DeleteShorthandRouteHandler extends BaseShorthandRouteHandl
     );
 
     let id = this._getIdForRequest(request);
-    modelClass.find(id).destroy();
+    let model = modelClass.find(id);
+    if (!model) {
+      return new Response(404);
+    }
+
+    model.destroy();
   }
 
   /*

--- a/lib/route-handlers/shorthands/put.js
+++ b/lib/route-handlers/shorthands/put.js
@@ -1,6 +1,7 @@
 import assert from "../../assert";
 import BaseShorthandRouteHandler from "./base";
 import { camelize } from "../../utils/inflector";
+import Response from "../../response";
 
 /**
  * @hide
@@ -21,11 +22,17 @@ export default class PutShorthandRouteHandler extends BaseShorthandRouteHandler 
     );
 
     let id = this._getIdForRequest(request);
+
+    let model = modelClass.find(id);
+    if (!model) {
+      return new Response(404);
+    }
+
     let attrs = this._getAttrsForRequest(
       request,
       modelClass.camelizedModelName
     );
 
-    return modelClass.find(id).update(attrs);
+    return model.update(attrs);
   }
 }


### PR DESCRIPTION
Before this PR the shorthand route handlers would return a Internal Server Error because `.find(id)` returns `undefined` and calling a method on `undefined` throws an error. This PR adds a check to both handlers that matches the behavior of the `GET` shorthand handler.